### PR TITLE
Fix: `'wa' is not defined` in Strict mode / module

### DIFF
--- a/getPointAtLengthLookup.js
+++ b/getPointAtLengthLookup.js
@@ -455,7 +455,7 @@
                 lgVals[lg] = getLegendreGaussValues(lg)
             }
 
-            wa = lgVals[lg]
+            const wa = lgVals[lg]
             let sum = 0;
 
             for (let i = 0, len = wa.length; i < len; i++) {


### PR DESCRIPTION
was getting `'wa' is not defined` when importing the library as a module. this fix resolves that 