### PR TITLE
Different from native at lengths larger than totalLength

### DIFF
--- a/getPointAtLengthLookup.js
+++ b/getPointAtLengthLookup.js
@@ -251,7 +251,7 @@
         if (length === 0) {
             return pt;
         }
-        else if (length === totalLength) {
+        else if (length >= totalLength) {
             let ptLast = seglast.points.slice(-1)[0]
             let angleLast = seglast.angles.slice(-1)[0]
 


### PR DESCRIPTION
When trying to find the point at a length larger than totalLength, this library returns the first point rather than the last point as the browser does.
Example using the codepen source:
![Image](https://github.com/user-attachments/assets/0b58d908-e97f-4bfa-9406-6bbd5c2fc6f5)

This can be fixed by changing the check for the last point to be greather than or equals, rather than strict equals
https://github.com/herrstrietzel/svg-getpointatlength/blob/2883d334a64006747ced57b17298ea97d7802a80/getPointAtLengthLookup.js#L254

After changing to `length >= totalLength`:

![Image](https://github.com/user-attachments/assets/d3e62fc4-eb27-44c4-9f2b-dd3f3368bde2)